### PR TITLE
[standard] Implement the Board interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -75,6 +75,7 @@ type Connection struct {
 }
 
 type Node interface {
+	Name() string
 	Connections() []Connection
 	Cities() []Player
 }

--- a/standard/board.go
+++ b/standard/board.go
@@ -1,0 +1,109 @@
+package standard
+
+import (
+	"encoding/csv"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/hinshun/powergrid"
+)
+
+// standardBoard implements the powergrid.Board interface
+type standardBoard struct {
+	nodes []powergrid.Node
+}
+
+// NewBoard constructs a standard Board
+func NewBoard(nodes []powergrid.Node) powergrid.Board {
+	return &standardBoard{
+		nodes: nodes,
+	}
+}
+
+// Nodes returns the nodes in the board
+func (b *standardBoard) Nodes() []powergrid.Node {
+	return b.nodes
+}
+
+// a standardNode is a standard implementation of the powergrid.Node interface
+type standardNode struct {
+	name        string
+	connections []powergrid.Connection
+	cities      []powergrid.Player
+}
+
+// Name returns the name of the node
+func (n *standardNode) Name() string {
+	return n.name
+}
+
+// Connections returns the connections of the node
+func (n *standardNode) Connections() []powergrid.Connection {
+	return n.connections
+}
+
+// Connections returns the cities on the node
+func (n *standardNode) Cities() []powergrid.Player {
+	return n.cities
+}
+
+// NewBoardFromCSV constructs a standard Board using a string
+// where each line is of the form:
+// <node name>, <weight>, <node name>
+// Each edge only needs to appear in the CSV once; this method will
+// not deduplicate multiple occurrences of the same edge
+// TODO(rabrams) refactor
+func NewBoardFromCSV(s string) (powergrid.Board, error) {
+	board := &standardBoard{}
+	ioReader := strings.NewReader(s)
+	csvReader := csv.NewReader(ioReader)
+	record, err := csvReader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	nodesByName := make(map[string]*standardNode)
+	for i := range record {
+		line := record[i]
+		if len(line) != 3 {
+			return nil, errors.New("line must be a triplet")
+		}
+		left := strings.Trim(line[0], " ")
+		right := strings.Trim(line[2], " ")
+		weight, err := strconv.ParseUint(strings.Trim(line[1], " "), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		leftNode, ok := nodesByName[left]
+		if !ok {
+			leftNode = &standardNode{
+				name: left,
+			}
+			nodesByName[left] = leftNode
+			board.nodes = append(
+				board.nodes,
+				leftNode)
+		}
+		rightNode, ok := nodesByName[right]
+		if !ok {
+			rightNode = &standardNode{
+				name: right,
+			}
+			nodesByName[right] = rightNode
+			board.nodes = append(
+				board.nodes,
+				rightNode)
+		}
+		leftNode.connections = append(leftNode.connections,
+			powergrid.Connection{
+				Cost: powergrid.Elektro(weight),
+				Node: rightNode,
+			})
+		rightNode.connections = append(
+			rightNode.connections, powergrid.Connection{
+				Cost: powergrid.Elektro(weight),
+				Node: leftNode,
+			})
+	}
+	return board, nil
+}

--- a/standard/board_test.go
+++ b/standard/board_test.go
@@ -1,0 +1,123 @@
+package standard
+
+// TODO(rabrams) import and use ginkgo
+import (
+	"reflect"
+	"testing"
+
+	"github.com/hinshun/powergrid"
+)
+
+const sampleCSVNoRecurrence = `Phoenix, 14, San Diego
+Denver, 16, Kansas City`
+
+const sampleCSVLeftRecurrence = `Denver, 0, Cheyenne
+Denver, 16, Kansas City`
+
+const sampleCSVRightRecurrence = `Phoenix, 14, San Diego
+Los Angeles, 3, San Diego`
+
+func TestCreateBoardFromCSVNoRecurrence(t *testing.T) {
+	board, err := NewBoardFromCSV(sampleCSVNoRecurrence)
+	if err != nil {
+		t.Fail()
+	}
+	nodesByName := make(map[string]powergrid.Node)
+	nodes := board.Nodes()
+	for i := range nodes {
+		node := nodes[i]
+		nodesByName[node.Name()] = node
+	}
+	// maps place name to its expected connection
+	testCases := map[string]powergrid.Connection{
+		"Phoenix": powergrid.Connection{
+			Cost: 14,
+			Node: nodesByName["San Diego"],
+		},
+		"San Diego": powergrid.Connection{
+			Cost: 14,
+			Node: nodesByName["Phoenix"],
+		},
+		"Denver": powergrid.Connection{
+			Cost: 16,
+			Node: nodesByName["Kansas City"],
+		},
+		"Kansas City": powergrid.Connection{
+			Cost: 16,
+			Node: nodesByName["Denver"],
+		},
+	}
+	for startName, expectedConnection := range testCases {
+		expectedConnections := []powergrid.Connection{
+			expectedConnection,
+		}
+		node := nodesByName[startName]
+		if !reflect.DeepEqual(expectedConnections, node.Connections()) {
+			t.Fail()
+		}
+	}
+}
+
+func TestCreateBoardFromCSVLeftRecurrence(t *testing.T) {
+	board, err := NewBoardFromCSV(sampleCSVLeftRecurrence)
+	if err != nil {
+		t.Fail()
+	}
+	nodesByName := make(map[string]powergrid.Node)
+	nodes := board.Nodes()
+	for i := range nodes {
+		node := nodes[i]
+		nodesByName[node.Name()] = node
+	}
+	denverNode := nodesByName["Denver"]
+	if len(denverNode.Connections()) != 2 {
+		t.Fail()
+	}
+	connections := denverNode.Connections()
+	for i := range connections {
+		connection := connections[i]
+		if connection.Node.Name() == "Cheyenne" {
+			if connection.Cost != 0 {
+				t.Fail()
+			}
+		} else if connection.Node.Name() == "Kansas City" {
+			if connection.Cost != 16 {
+				t.Fail()
+			}
+		} else {
+			t.Fail()
+		}
+	}
+}
+
+func TestCreateBoardFromCSVRightRecurrence(t *testing.T) {
+	board, err := NewBoardFromCSV(sampleCSVRightRecurrence)
+	if err != nil {
+		t.Fail()
+	}
+	nodesByName := make(map[string]powergrid.Node)
+	nodes := board.Nodes()
+	for i := range nodes {
+		node := nodes[i]
+		nodesByName[node.Name()] = node
+	}
+	sdNode := nodesByName["San Diego"]
+	if len(sdNode.Connections()) != 2 {
+		t.Fail()
+	}
+	connections := sdNode.Connections()
+	for i := range connections {
+		connection := connections[i]
+		if connection.Node.Name() == "Los Angeles" {
+			if connection.Cost != 3 {
+				t.Fail()
+			}
+		} else if connection.Node.Name() == "Phoenix" {
+			if connection.Cost != 14 {
+				t.Fail()
+			}
+		} else {
+			t.Fail()
+		}
+	}
+}

--- a/standard/power_plant.go
+++ b/standard/power_plant.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hinshun/powergrid"
 )
 
-// PowerPlant is an implementation of the powergrid.PowerPlant
+// standardPowerPlant is an implementation of the powergrid.PowerPlant
 // interface that works for the game's standard power plants
 type standardPowerPlant struct {
 	ordinal       uint


### PR DESCRIPTION
Part of an effort to create the mechanics for basic game play this change
creates a struct that implements the Board interface for standard games as well
as a constructor for creating board from CSVs. CSVs will allow the board
definitions to be language agnostic and easier to write.

Closes #14